### PR TITLE
Quickfix for issue #1

### DIFF
--- a/tags.js
+++ b/tags.js
@@ -8,7 +8,7 @@ exports.codepen = {
         var useCurData = validCurData && (typeof curData.description === "string") && !curData.body;
 
         // copies codepen options on to the docObject so they are accessible by the script
-        if(options.siteConfig.codepen) {
+        if(options.siteConfig && options.siteConfig.codepen) {
             this.codepen = options.siteConfig.codepen;
         }
 


### PR DESCRIPTION
This is the referenced fix mentioned in the comments in line #1. It probably needs an appropriate test.

This fix ensures that when checking `options.siteConfig` is defined before checking `options.siteConfig.codepen`.