### PR TITLE
Remove the <script type="module"> hack

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,12 +119,6 @@ module.exports = function() {
                 if(data.html) {
                     data.html = data.html.trim();
                 }
-                if (data.js && data.js.indexOf('import') > -1) {
-                    var jsAsModule = "<script type=\"module\">\n" + data.js + "\n</script>";
-                    data.html = data.html ? data.html + "\n\n" + jsAsModule : jsAsModule;
-                    data.js = "";
-                    data.editors = "1001";// HTML, Result, & Console
-                }
                 if(data) {
                     cleanCodePenData(data);
                     if(window.CREATE_CODE_PEN) {
@@ -143,10 +137,6 @@ module.exports = function() {
 
                 var jsCode = el.querySelector("[data-for=js] code");
                 var jsText = jsCode ? jsCode.textContent.trim() : "";
-                if (jsText) {
-                    htmlText += "\n<script type=\"module\">\n" + jsText + "\n</script>";
-                    jsText = "";
-                }
 
                 var cssText = getStylesFromIframe( el.querySelector("iframe") );
 

--- a/test.js
+++ b/test.js
@@ -60,17 +60,16 @@ describe("bit-docs-html-codepen-link", function() {
 					codePen.click();
 				});
 				assert.deepEqual(createCallData, [{
-						html: '<my-app></my-app>\n\n<script type="module">\nimport { Component } from "//unpkg.com/can@^5.0.0-pre.1/core.mjs";\nComponent\n</script>',
-						js: '',
+						html: '<my-app></my-app>',
+						js: 'import { Component } from "//unpkg.com/can@^5.0.0-pre.1/core.mjs";\nComponent',
 						js_module: true,
-						editors: '1001',
+						editors: '1011',
 						css: 'my-app {color: "green";}'
 					},
 					{
-						html: '<script type="module">\nimport {DefineMap} from "//unpkg.com/can@^5.0.0-pre.1/core.mjs";\nconsole.log( myCounter.count ) //-> 1\n</script>',
-						js: '',
+						js: 'import {DefineMap} from "//unpkg.com/can@^5.0.0-pre.1/core.mjs";\nconsole.log( myCounter.count ) //-> 1',
 						js_module: true,
-						editors: '1001'
+						editors: '0011'
 					}
 				]);
 


### PR DESCRIPTION
In order to work around a CodePen issue, everything in the JS tab was put into the HTML tab, surrounded by `<script type="module">`

This commit removes that workaround now that CodePen has said it will support module detection for the foreseeable future.

Part of https://github.com/bit-docs/bit-docs-html-codepen-link/issues/3